### PR TITLE
Repository changes

### DIFF
--- a/MiniTwit.Entities/Message.cs
+++ b/MiniTwit.Entities/Message.cs
@@ -11,7 +11,7 @@ namespace MiniTwit.Entities
         public User Author { get; set;}
         [Required]
         public string Text { get; set;} 
-        public int PubDate { get; set;}
+        public DateTime Pubdate { get; set; }
 
         public int Flagged { get; set;}
         

--- a/MiniTwit.Models.Test/MessageRepositoryTests.cs
+++ b/MiniTwit.Models.Test/MessageRepositoryTests.cs
@@ -1,10 +1,12 @@
 using System;
+using System.Globalization;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using MiniTwit.Entities;
 using Xunit;
+using Xunit.Abstractions;
 using static MiniTwit.Models.Tests.Utility;
 using static MiniTwit.Models.Tests.MiniTwitTestContext;
 
@@ -12,34 +14,56 @@ namespace MiniTwit.Models.Tests
 {
     public class MessageRepositoryTests
     {
+        private readonly ITestOutputHelper _testOutputHelper;
+        private readonly MiniTwitTestContext _context;
+        private readonly UserRepository _userRepository;
+        private readonly MessageRepository _messageRepository;
+
+        public MessageRepositoryTests(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+            _context = CreateMiniTwitContext();
+            _context.Database.EnsureDeleted();
+            _context.Database.EnsureCreated();
+            _userRepository = new UserRepository(_context);
+            _messageRepository = new MessageRepository(_context);
+        }
 
         
 
         [Fact]
         public async Task Message_Is_Created_Succesfully()
         {
-            MiniTwitContext context = CreateMiniTwitContext();
-            MessageRepository repo = new MessageRepository(context);
-            var userRepo = new UserRepository(context);
-            MessageRepository messageRepo = new MessageRepository(context);
-            await Add_dummy_data(userRepo, messageRepo);
-            (_, int id) = await userRepo.CreateAsync(new User() {UserName ="Test", Email="qwfqwf@qdqw.qwf"});
+            await Add_dummy_data(_userRepository, _messageRepository);
+            (_, int id) = await _userRepository.CreateAsync(new User() {UserName ="Test", Email="qwfqwf@qdqw.qwf"});
 
-            var result = await repo.CreateAsync(new Message() { Text ="qwdqg", AuthorId=id});
+            var (response, messageId) = await _messageRepository.CreateAsync(new Message() { Text ="qwdqg", AuthorId=id});
 
-            Assert.Equal(Response.Created, result.response);
-            Assert.Equal(10, result.messageId); //todo should probably find a way to figure out expected that doesn't break when dummydata is created.
+            Assert.Equal(Response.Created, response);
+            Assert.Equal(10, messageId); //todo should probably find a way to figure out expected that doesn't break when dummydata is created.
 
         }
 
        [Fact]
         public async Task Message_without_author_fails()
         {
-            MiniTwitContext context = CreateMiniTwitContext();
-            MessageRepository repo = new MessageRepository(context);
+            await Assert.ThrowsAsync<DbUpdateException>(() => _messageRepository.CreateAsync(new Message() { Text ="qwdqg"}));
 
-            await Assert.ThrowsAsync<DbUpdateException>(() => repo.CreateAsync(new Message() { Text ="qwdqg"}));
+        }
 
+        [Fact]
+        public async Task Read_messages_in_pubdate_order()
+        {
+            await Add_dummy_data(_userRepository, _messageRepository);
+            var result = await _messageRepository.ReadAsync();
+            DateTime prev = DateTime.MinValue;
+            foreach (var message in result)
+            {
+                Assert.True(DateTime.Compare(prev, message.Pubdate) < 0);
+                _testOutputHelper.WriteLine(message.Pubdate.ToString(CultureInfo.InvariantCulture));
+                prev = message.Pubdate;
+            
+            }
         }
        
 

--- a/MiniTwit.Models.Test/MessageRepositoryTests.cs
+++ b/MiniTwit.Models.Test/MessageRepositoryTests.cs
@@ -21,13 +21,14 @@ namespace MiniTwit.Models.Tests
             MiniTwitContext context = CreateMiniTwitContext();
             MessageRepository repo = new MessageRepository(context);
             var userRepo = new UserRepository(context);
-            await Add_dummy_data(userRepo);
+            MessageRepository messageRepo = new MessageRepository(context);
+            await Add_dummy_data(userRepo, messageRepo);
             (_, int id) = await userRepo.CreateAsync(new User() {UserName ="Test", Email="qwfqwf@qdqw.qwf"});
 
             var result = await repo.CreateAsync(new Message() { Text ="qwdqg", AuthorId=id});
 
             Assert.Equal(Response.Created, result.response);
-            Assert.Equal(1, result.messageId);
+            Assert.Equal(10, result.messageId); //todo should probably find a way to figure out expected that doesn't break when dummydata is created.
 
         }
 
@@ -36,7 +37,6 @@ namespace MiniTwit.Models.Tests
         {
             MiniTwitContext context = CreateMiniTwitContext();
             MessageRepository repo = new MessageRepository(context);
-            await Add_dummy_data(new UserRepository(context));
 
             await Assert.ThrowsAsync<DbUpdateException>(() => repo.CreateAsync(new Message() { Text ="qwdqg"}));
 

--- a/MiniTwit.Models.Test/MessageRepositoryTests.cs
+++ b/MiniTwit.Models.Test/MessageRepositoryTests.cs
@@ -40,7 +40,7 @@ namespace MiniTwit.Models.Tests
             var (response, messageId) = await _messageRepository.CreateAsync(new Message() { Text ="qwdqg", AuthorId=id});
 
             Assert.Equal(Response.Created, response);
-            Assert.Equal(10, messageId); //todo should probably find a way to figure out expected that doesn't break when dummydata is created.
+            Assert.Equal(12, messageId); //todo should probably find a way to figure out expected that doesn't break when dummydata is created.
 
         }
 
@@ -66,6 +66,15 @@ namespace MiniTwit.Models.Tests
             }
         }
        
-
+        [Fact]
+        public async Task Read_messages_contains_no_flagged()
+        {
+            await Add_dummy_data(_userRepository, _messageRepository);
+            var result = await _messageRepository.ReadAsync();
+            foreach (var message in result)
+            {
+                Assert.True(message.Flagged <= 0);
+            }
+        }
     }
 }

--- a/MiniTwit.Models.Test/MessageRepositoryTests.cs
+++ b/MiniTwit.Models.Test/MessageRepositoryTests.cs
@@ -65,12 +65,64 @@ namespace MiniTwit.Models.Tests
             
             }
         }
+        
+        [Fact]
+        public async Task ReadCount_messages_in_pubdate_order()
+        {
+            await Add_dummy_data(_userRepository, _messageRepository);
+            var result = await _messageRepository.ReadCountAsync(12);
+            DateTime prev = DateTime.MinValue;
+            foreach (var message in result)
+            {
+                Assert.True(DateTime.Compare(prev, message.Pubdate) < 0);
+                _testOutputHelper.WriteLine(message.Pubdate.ToString(CultureInfo.InvariantCulture));
+                prev = message.Pubdate;
+            
+            }
+        }
+        
+        [Fact]
+        public async Task ReadAllMessagesFromUser_messages_in_pubdate_order()
+        {
+            await Add_dummy_data(_userRepository, _messageRepository);
+            var result = await _messageRepository.ReadAllMessagesFromUserAsync(1);
+            DateTime prev = DateTime.MinValue;
+            foreach (var message in result)
+            {
+                Assert.True(DateTime.Compare(prev, message.Pubdate) < 0);
+                _testOutputHelper.WriteLine(message.Pubdate.ToString(CultureInfo.InvariantCulture));
+                prev = message.Pubdate;
+            
+            }
+        }
        
         [Fact]
         public async Task Read_messages_contains_no_flagged()
         {
             await Add_dummy_data(_userRepository, _messageRepository);
             var result = await _messageRepository.ReadAsync();
+            foreach (var message in result)
+            {
+                Assert.True(message.Flagged <= 0);
+            }
+        }
+        
+        [Fact]
+        public async Task ReadCount_messages_contains_no_flagged()
+        {
+            await Add_dummy_data(_userRepository, _messageRepository);
+            var result = await _messageRepository.ReadCountAsync(12);
+            foreach (var message in result)
+            {
+                Assert.True(message.Flagged <= 0);
+            }
+        }
+        
+        [Fact]
+        public async Task ReadMessagesFromUser_messages_contains_no_flagged()
+        {
+            await Add_dummy_data(_userRepository, _messageRepository);
+            var result = await _messageRepository.ReadAllMessagesFromUserAsync(1);
             foreach (var message in result)
             {
                 Assert.True(message.Flagged <= 0);

--- a/MiniTwit.Models.Test/MiniTwitTestContext.cs
+++ b/MiniTwit.Models.Test/MiniTwitTestContext.cs
@@ -17,7 +17,7 @@ namespace MiniTwit.Models.Tests
             _connection = connection;
         }
 
-        public static MiniTwitTestContext CreateMiniTwitContext([CallerMemberName] string testName = "", [CallerFilePath] string testNamePart2 = "")
+        public static MiniTwitTestContext CreateMiniTwitContext([CallerMemberName] string testName = "", [CallerFilePath] string testNamePart2 = "") 
         {
             var connection = new SqliteConnection("Datasource=:memory:");
             connection.Open();

--- a/MiniTwit.Models.Test/UserRepositoryTests.cs
+++ b/MiniTwit.Models.Test/UserRepositoryTests.cs
@@ -18,9 +18,9 @@ namespace MiniTwit.Models.Tests
         public async Task User_Is_Created_Succesfully()
         {
             var context = CreateMiniTwitContext();
-            UserRepository repo = new UserRepository(context);
+            UserRepository userRepo = new UserRepository(context);
 
-            var result = await repo.CreateAsync(new User() { UserName = "TestCreate", Email = "qwdq@gqqw.com" });
+            var result = await userRepo.CreateAsync(new User() { UserName = "TestCreate", Email = "qwdq@gqqw.com" });
 
             Assert.Equal(Response.Created, result.response);
             Assert.Equal(1, result.userId);
@@ -87,7 +87,8 @@ namespace MiniTwit.Models.Tests
         {
             var context = CreateMiniTwitContext();
             UserRepository repo = new UserRepository(context);
-            await Add_dummy_data(repo);
+            MessageRepository messageRepo = new MessageRepository(context);
+            await Add_dummy_data(repo, messageRepo);
 
 
             var user = new User
@@ -107,7 +108,8 @@ namespace MiniTwit.Models.Tests
         {
             var context = CreateMiniTwitContext();
             UserRepository repo = new UserRepository(context);
-            await Add_dummy_data(repo);
+            MessageRepository messageRepo = new MessageRepository(context);
+            await Add_dummy_data(repo, messageRepo);
 
             var users = await repo.ReadAsync();
 
@@ -119,7 +121,8 @@ namespace MiniTwit.Models.Tests
         {
             var context = CreateMiniTwitContext();
             UserRepository repo = new UserRepository(context);
-            await Add_dummy_data(repo);
+            MessageRepository messageRepo = new MessageRepository(context);
+            await Add_dummy_data(repo, messageRepo);
 
             var users = await repo.ReadAsync();
 
@@ -131,7 +134,8 @@ namespace MiniTwit.Models.Tests
         {
             var context = CreateMiniTwitContext();
             UserRepository repo = new UserRepository(context);
-            await Add_dummy_data(repo);
+            MessageRepository messageRepo = new MessageRepository(context);
+            await Add_dummy_data(repo, messageRepo);
 
             var users = await repo.ReadAsync();
 
@@ -182,7 +186,8 @@ namespace MiniTwit.Models.Tests
         {
             var context = CreateMiniTwitContext();
             UserRepository repo = new UserRepository(context);
-            await Add_dummy_data(repo);
+            MessageRepository messageRepo = new MessageRepository(context);
+            await Add_dummy_data(repo, messageRepo);
 
             var user = new User { Id = 1, UserName = "user120", Email = "user2@kanban.com" };
 
@@ -196,7 +201,8 @@ namespace MiniTwit.Models.Tests
         {
             var context = CreateMiniTwitContext();
             UserRepository repo = new UserRepository(context);
-            await Add_dummy_data(repo);
+            MessageRepository messageRepo = new MessageRepository(context);
+            await Add_dummy_data(repo, messageRepo);
 
             var user = new User { Id = 2, UserName = "newuser2", Email = "newuser2@kanban.com" };
 
@@ -213,7 +219,8 @@ namespace MiniTwit.Models.Tests
         {
             var context = CreateMiniTwitContext();
             UserRepository repo = new UserRepository(context);
-            await Add_dummy_data(repo);
+            MessageRepository messageRepo = new MessageRepository(context);
+            await Add_dummy_data(repo, messageRepo);
 
             var user = new User { Id = 2, UserName = "newuser2", Email = "newuser2@kanban.com" };
 
@@ -221,8 +228,5 @@ namespace MiniTwit.Models.Tests
 
             Assert.Equal(Response.Updated, response);
         }
-
-
-
     }
 }

--- a/MiniTwit.Models.Test/Utility.cs
+++ b/MiniTwit.Models.Test/Utility.cs
@@ -36,6 +36,14 @@ namespace MiniTwit.Models.Tests
                 Text = "waddup"
             };
             await messageRepository.CreateAsync(extraMessage);
+            var extraMessage2 = new Message
+            {
+                Author = extrauser,
+                Pubdate = new DateTime(2018, 1, 2),
+                Text = "waddup",
+                Flagged = 1
+            };
+            await messageRepository.CreateAsync(extraMessage2);
         }
     }
 }

--- a/MiniTwit.Models.Test/Utility.cs
+++ b/MiniTwit.Models.Test/Utility.cs
@@ -1,4 +1,5 @@
-﻿using MiniTwit.Entities;
+﻿using System;
+using MiniTwit.Entities;
 using System.Threading.Tasks;
 
 namespace MiniTwit.Models.Tests
@@ -7,16 +8,23 @@ namespace MiniTwit.Models.Tests
     {
         
 
-        public static async Task Add_dummy_data(UserRepository repository)
+        public static async Task Add_dummy_data(UserRepository userRepository, MessageRepository messageRepository)
         {
-            for (int i = 1; i < 10; i++)
+            for (var i = 1; i < 10; i++)
             {
                 var user1 = new User
                 {
                     UserName = "user" + i,
                     Email = "user" + i + "@kanban.com"
                 };
-                var (_, _) = await repository.CreateAsync(user1);
+                var message1 = new Message
+                {
+                    Author = user1,
+                    Pubdate = new DateTime(2019, 1, i),
+                    Text = "waddup" + i
+                };
+                await userRepository.CreateAsync(user1);
+                await messageRepository.CreateAsync(message1);
             }
         }
     }

--- a/MiniTwit.Models.Test/Utility.cs
+++ b/MiniTwit.Models.Test/Utility.cs
@@ -10,6 +10,7 @@ namespace MiniTwit.Models.Tests
 
         public static async Task Add_dummy_data(UserRepository userRepository, MessageRepository messageRepository)
         {
+            var extrauser = new User();
             for (var i = 1; i < 10; i++)
             {
                 var user1 = new User
@@ -23,9 +24,18 @@ namespace MiniTwit.Models.Tests
                     Pubdate = new DateTime(2019, 1, i),
                     Text = "waddup" + i
                 };
+                extrauser = user1;
                 await userRepository.CreateAsync(user1);
                 await messageRepository.CreateAsync(message1);
             }
+
+            var extraMessage = new Message
+            {
+                Author = extrauser,
+                Pubdate = new DateTime(2018, 1, 1),
+                Text = "waddup"
+            };
+            await messageRepository.CreateAsync(extraMessage);
         }
     }
 }

--- a/MiniTwit.Models/MessageRepository.cs
+++ b/MiniTwit.Models/MessageRepository.cs
@@ -29,8 +29,8 @@ namespace MiniTwit.Models
         {
             var query = from m in _context.Messages
                 where m.Flagged <= 0
-                        orderby m.Pubdate
-                        select m;
+                orderby m.Pubdate
+                select m;
 
             return await query.ToListAsync();
         }
@@ -48,8 +48,9 @@ namespace MiniTwit.Models
         public async Task<Message> ReadAsync(int messageId)
         {
             var messages = from m in _context.Messages
-                        where m.Id == messageId
-                        select m;
+                where m.Flagged <= 0
+                where m.Id == messageId
+                select m;
 
             return await messages.FirstOrDefaultAsync();
         }
@@ -57,9 +58,10 @@ namespace MiniTwit.Models
         public async Task<List<Message>> ReadAllMessagesFromUserAsync(int userId)
         {
             var messages = from m in _context.Messages
-                           where m.AuthorId == userId
-                           select m;
-
+                where m.Flagged <= 0
+                where m.AuthorId == userId
+                orderby m.Pubdate
+                select m;
             return await messages.ToListAsync();
         }
 

--- a/MiniTwit.Models/MessageRepository.cs
+++ b/MiniTwit.Models/MessageRepository.cs
@@ -28,7 +28,8 @@ namespace MiniTwit.Models
         public async Task<IEnumerable<Message>> ReadAsync()
         {
             var query = from m in _context.Messages
-                        orderby m.Id
+                where m.Flagged <= 0
+                        orderby m.Pubdate
                         select m;
 
             return await query.ToListAsync();
@@ -37,7 +38,8 @@ namespace MiniTwit.Models
         public async Task<IEnumerable<Message>> ReadCountAsync(int count)
         {
             var query = from m in _context.Messages
-                orderby m.Id
+                where m.Flagged <= 0
+                orderby m.Pubdate
                 select m;
 
             return await query.Take(count).ToListAsync();

--- a/MiniTwit.Web.App/Controllers/HomeController.cs
+++ b/MiniTwit.Web.App/Controllers/HomeController.cs
@@ -46,6 +46,7 @@ namespace MiniTwit.Web.App.Controllers
         {
             ViewData["ReturnUrl"] = returnUrl;
             int actualId = 0;
+            // ReSharper disable once Mvc.ViewNotResolved
             if (!Int32.TryParse(id, out actualId)) return View(model);
             model.AuthorId = actualId;
             model.Author = await _userRepository.ReadAsync(actualId);

--- a/MiniTwit.Web.App/Views/Home/Index.cshtml
+++ b/MiniTwit.Web.App/Views/Home/Index.cshtml
@@ -69,7 +69,7 @@
                     </strong>
                     @msg.Text
                     <small>
-                        &mdash; @msg.PubDate
+                        &mdash; @msg.Pubdate @*todo check if this look right*@
                     </small>
                 </li>
             }


### PR DESCRIPTION
Resolves #50 Repository reads now no longer returned flagged messages, and messages are returned in order of publication, rather than ID. There are also slightly more tests than before.