### PR TITLE
Added restart policy to production config

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,6 +2,7 @@ version: "3.4"
 services:
     database:
         image: postgres:12
+        restart: unless-stopped
         environment:
             - "POSTGRES_PASSWORD=test"
         volumes:
@@ -12,6 +13,7 @@ services:
             context: "."
             dockerfile: "Dockerfile"
             target: production
+        restart: unless-stopped
         environment:
             - "ASPNETCORE_ENVIRONMENT=Production"
             - "MINITWIT_ENVIRONMENT=docker"


### PR DESCRIPTION
This is small extension to #69.

The PR defines a restart policy for the containers in production. This means that the containers will restart if the server reboots (unexpectedly or not), and makes sure we don't forget to start the service after reboots.

Here are the diffrent restart policies
| Flag | Description |
| ------ | --------------- |
| `no`    | Do not automatically restart the container. (the default) |
| `on-failure`    | Restart the container if it exits due to an error, which manifests as a non-zero exit code. |
| `always`    | Always restart the container if it stops. If it is manually stopped, it is restarted only when Docker daemon restarts or the container itself is manually restarted. |
| `unless-stopped`    | Similar to `always`, except that when the container is stopped (manually or otherwise), it is not restarted even after Docker daemon restarts. |

Source: https://docs.docker.com/config/containers/start-containers-automatically.

I chose unless-stopped instead of always so that we still have the ability to shut down the service, for what ever reason.