### PR TITLE
Continuous deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,13 +7,14 @@ name: Build, push and deploy on push to master
 on: [push]
 
 jobs:
-    build:
+    deploy:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
             - name: Log into dockerhub
               run: echo "${{ secrets.DOCKER_TOKEN }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
-            # Investigate Caching
+            - name: Download docker build cache
+              run: docker-compose -f docker-compose.prod.yml pull webapp
             - name: Build with docker compose
               run: docker-compose -f docker-compose.prod.yml build
             - name: Push docker images to docker hub
@@ -21,16 +22,20 @@ jobs:
             - name: Configure deployment credentials
               uses: shimataro/ssh-key-action@v2
               with:
-                key: ${{ secrets.SSH_PRIVATE_KEY }}
-                known_hosts: ${{ secrets.SSH_HOST }}
+                  key: ${{ secrets.SSH_PRIVATE_KEY }}
+                  known_hosts: ${{ secrets.SSH_HOST }}
+                  name: devops_rsa
+                  config: |
+                    Host ${{ secrets.SSH_USERNAME }}
+                        IdentityFile ~/.ssh/devops_rsa
             # Deploy
             - name: Deploy to Production
               uses: fifsky/ssh-action@master
               with:
-                host: ${{ secrets.SSH_HOST }}
-                user: ${{ secrets.USERNAME }}
-                key: ${{ secrets.SSH_PRIVATE_KEY }}
-                command: |
-                    cd devoops
-                    git pull
-                    ./deploy.sh
+                  host: ${{ secrets.SSH_HOST }}
+                  user: ${{ secrets.SSH_USERNAME }}
+                  key: ${{ secrets.SSH_PRIVATE_KEY }}
+                  command: |
+                      cd devoops
+                      git pull
+                      ./deploy.sh

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,7 @@ jobs:
               with:
                 host: ${{ secrets.SSH_HOST }}
                 username: ${{ secrets.USERNAME }}
+                key: ${{ secrets.SSH_PRIVATE_KEY }}
                 script: |
                     cd devoops
                     git pull

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,4 +24,4 @@ jobs:
                 ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
             # Deploy
             - name: Deploy on production
-              run: docker-compose -H "ssh://${{ secrets.SSH_USERNAME }}@${{ secrets.SSH_HOST }}" up -d
+              run: docker-compose -H "ssh://root@${{ secrets.SSH_HOST }}" up -d

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,10 +1,9 @@
 name: Build, push and deploy on push to master
 
-# on:
-#     push:
-#         branches:
-#             - master
-on: [push]
+on:
+    push:
+        branches:
+            - master
 
 jobs:
     deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,10 +25,11 @@ jobs:
                 known_hosts: ${{ secrets.SSH_HOST }}
             # Deploy
             - name: Deploy to Production
-              uses: JorgenVatle/docker-compose-deploy@v1.0
+              uses: appleboy/ssh-action@master
               with:
-                deploy_targets: '${{ secrets.SSH_HOST }}' # required, comma separated list of servers to deploy to.
-
-                ssh_user: '${{ secrets.SSH_USERNAME }}' # optional, user to connect to deploy targets with. Defaults to 'root'
-                compose_file: 'docker-compose.prod.yml' # optional, path/filename of your docker-compose file. Defaults to 'docker-compose.yml'
-                #validate_container: 'devoops_webapp_1' # optional, validate that the given container name is running. Otherwise, throw an error. Defaults to 'app'   
+                host: ${{ secrets.SSH_HOST }}
+                username: ${{ secrets.USERNAME }}
+                script: |
+                    cd devoops
+                    git pull
+                    ./deploy.sh

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,4 +24,4 @@ jobs:
                 ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
             # Deploy
             - name: Deploy on production
-              run: docker-compose -H "ssh://root@${{ secrets.SSH_HOST }}" up -d
+              run: docker-compose -H "ssh://${{ secrets.SSH_USERNAME }}@${{ secrets.SSH_HOST }}" up -d

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,10 +21,10 @@ jobs:
             - name: Configure deployment credentials
               uses: shimataro/ssh-key-action@v2
               with:
-                ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+                key: ${{ secrets.SSH_PRIVATE_KEY }}
                 known_hosts: ${{ secrets.SSH_HOST }}
             # Deploy
-            - name: Deploy to Staging
+            - name: Deploy to Production
               uses: JorgenVatle/docker-compose-deploy@v1.0
               with:
                 deploy_targets: '${{ secrets.SSH_HOST }}' # required, comma separated list of servers to deploy to.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,15 +12,15 @@ jobs:
         steps:
             - uses: actions/checkout@v2
             - name: Log into dockerhub
-            - run: echo "${{ secrets.DOCKER_TOKEN }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+              run: echo "${{ secrets.DOCKER_TOKEN }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
             # Investigate Caching
             - name: Build with docker compose
-            - run: docker-compose -f docker-compose.prod.yml build
+              run: docker-compose -f docker-compose.prod.yml build
             - name: Push docker images to docker hub
-            - run: docker-compose -f docker-compose.prod.yml push
+              run: docker-compose -f docker-compose.prod.yml push
 
             - name: Configure deployment credentials
-            - run: echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+              run: echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
             # Deploy
             - name: Deploy on production
-            - run: docker-compose -H "ssh://${{ secrets.SSH_USERNAME }}@${{ secrets.SSH_HOST }}" up -d
+              run: docker-compose -H "ssh://${{ secrets.SSH_USERNAME }}@${{ secrets.SSH_HOST }}" up -d

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,9 +18,10 @@ jobs:
               run: docker-compose -f docker-compose.prod.yml build
             - name: Push docker images to docker hub
               run: docker-compose -f docker-compose.prod.yml push
-
             - name: Configure deployment credentials
-              run: echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+              uses: webfactory/ssh-agent@v0.2.0
+              with:
+                ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
             # Deploy
             - name: Deploy on production
               run: docker-compose -H "ssh://${{ secrets.SSH_USERNAME }}@${{ secrets.SSH_HOST }}" up -d

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,9 +19,16 @@ jobs:
             - name: Push docker images to docker hub
               run: docker-compose -f docker-compose.prod.yml push
             - name: Configure deployment credentials
-              uses: webfactory/ssh-agent@v0.2.0
+              uses: shimatoro/ssh-key-action@v2
               with:
                 ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+                known_hosts: ${{ secrets.SSH_HOST }}
             # Deploy
-            - name: Deploy on production
-              run: docker-compose -H "ssh://${{ secrets.SSH_USERNAME }}@${{ secrets.SSH_HOST }}" up -d
+            - name: Deploy to Staging
+              uses: JorgenVatle/docker-compose-deploy@v1.0
+                with:
+                deploy_targets: '${{ secrets.SSH_HOST }}' # required, comma separated list of servers to deploy to.
+
+                ssh_user: '${{ secrets.SSH_USERNAME }}' # optional, user to connect to deploy targets with. Defaults to 'root'
+                compose_file: 'docker-compose.prod.yml' # optional, path/filename of your docker-compose file. Defaults to 'docker-compose.yml'
+                #validate_container: 'devoops_webapp_1' # optional, validate that the given container name is running. Otherwise, throw an error. Defaults to 'app'   

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,10 @@
 name: Build, push and deploy on push to master
 
-on:
-    push:
-        branches:
-            - master
+# on:
+#     push:
+#         branches:
+#             - master
+on: [push]
 
 jobs:
     build:
@@ -18,11 +19,8 @@ jobs:
             - name: Push docker images to docker hub
             - run: docker-compose -f docker-compose.prod.yml push
 
+            - name: Configure deployment credentials
+            - run: echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
             # Deploy
             - name: Deploy on production
-            - run: docker-compose -H "ssh://${{ secrets.SSH_USERNAME }}@${{ secrets.SSH_HOST }}" up
-    # deploy:
-    #     name: Build
-    #     runs-on: ubuntu-latest
-    #     steps:
-    #         -
+            - run: docker-compose -H "ssh://${{ secrets.SSH_USERNAME }}@${{ secrets.SSH_HOST }}" up -d

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,28 @@
+name: Build, push and deploy on push to master
+
+on:
+    push:
+        branches:
+            - master
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - name: Log into dockerhub
+            - run: echo "${{ secrets.DOCKER_TOKEN }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+            # Investigate Caching
+            - name: Build with docker compose
+            - run: docker-compose -f docker-compose.prod.yml build
+            - name: Push docker images to docker hub
+            - run: docker-compose -f docker-compose.prod.yml push
+
+            # Deploy
+            - name: Deploy on production
+            - run: docker-compose -H "ssh://${{ secrets.SSH_USERNAME }}@${{ secrets.SSH_HOST }}" up
+    # deploy:
+    #     name: Build
+    #     runs-on: ubuntu-latest
+    #     steps:
+    #         -

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,12 +25,12 @@ jobs:
                 known_hosts: ${{ secrets.SSH_HOST }}
             # Deploy
             - name: Deploy to Production
-              uses: appleboy/ssh-action@master
+              uses: fifsky/ssh-action@master
               with:
                 host: ${{ secrets.SSH_HOST }}
-                username: ${{ secrets.USERNAME }}
+                user: ${{ secrets.USERNAME }}
                 key: ${{ secrets.SSH_PRIVATE_KEY }}
-                script: |
+                command: |
                     cd devoops
                     git pull
                     ./deploy.sh

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
             - name: Push docker images to docker hub
               run: docker-compose -f docker-compose.prod.yml push
             - name: Configure deployment credentials
-              uses: shimatoro/ssh-key-action@v2
+              uses: shimataro/ssh-key-action@v2
               with:
                 ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
                 known_hosts: ${{ secrets.SSH_HOST }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
             # Deploy
             - name: Deploy to Staging
               uses: JorgenVatle/docker-compose-deploy@v1.0
-                with:
+              with:
                 deploy_targets: '${{ secrets.SSH_HOST }}' # required, comma separated list of servers to deploy to.
 
                 ssh_user: '${{ secrets.SSH_USERNAME }}' # optional, user to connect to deploy targets with. Defaults to 'root'

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -44,6 +44,8 @@ services:
             context: "."
             dockerfile: "Dockerfile"
             target: production
+            cache_from:
+                - jlndk/devoops:latest
         image: jlndk/devoops:latest
         restart: unless-stopped
         environment:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -44,6 +44,7 @@ services:
             context: "."
             dockerfile: "Dockerfile"
             target: production
+        image: jlndk/devoops:latest
         restart: unless-stopped
         environment:
             - "ASPNETCORE_ENVIRONMENT=Production"


### PR DESCRIPTION
~Does not work. Dont merge~
This PR adds Continous Deployment to our pipeline.
It is triggered every time a commit is added to master (which also includes merges), and works by first building the docker image and afterwards push it to the docker registry.
Afterwards the action SSH into the server, pulls git, and runs our deployment script.

We could improve this pipeline by using the docker socket over ssh (using the -h argument) instead of running commands directly on the server to improve reliability and eliminate the need for git/ a local version of the source code on the server. I however think that we should merge this and improve afterwards, so that we can actually have CD.

Even though we have some degree of docker caching in this PR, I won't say it is enough to solve #90. Currently we only push the "prod" stage of our docker image to the registry, thus only being able to download that for caching. If we want full caching we should also push/pull the "build" stage seperatly.

Solves #53.
Solves #54.
Solves #55.