### PR TITLE
Pollish Frontend (and made it more mobile friendly in the process).

### DIFF
--- a/MiniTwit.Web.App/Views/Account/LogIn.cshtml
+++ b/MiniTwit.Web.App/Views/Account/LogIn.cshtml
@@ -6,39 +6,31 @@
     ViewData["Title"] = "Sign In";
 }
 
-<h2>Sign In</h2>
-<div class="row">
-    <div class="col-md-4">
-        <section>
-            <form asp-route-returnurl="@ViewData["ReturnUrl"]" method="post">
-                <h4>Use a local account to log in.</h4>
-                <hr/>
-                <div asp-validation-summary="All" class="text-danger"></div>
-                <div class="form-group">
-                    <label asp-for="UserName"></label>
-                    <input asp-for="UserName" class="form-control"/>
-                    <span asp-validation-for="UserName" class="text-danger"></span>
-                </div>
-                <div class="form-group">
-                    <label asp-for="Password"></label>
-                    <input asp-for="Password" class="form-control"/>
-                    <span asp-validation-for="Password" class="text-danger"></span>
-                </div>
-                <div class="form-group">
-                    <div class="checkbox">
-                        <label asp-for="RememberMe">
-                            <input asp-for="RememberMe"/>
-                            @Html.DisplayNameFor(m => m.RememberMe)
-                        </label>
-                    </div>
-                </div>
-                <div class="form-group">
-                    <button type="submit" class="btn btn-default">Log in</button>
-                </div>
-            </form>
-        </section>
+<h2>@ViewData["Title"]</h2>
+<form asp-route-returnurl="@ViewData["ReturnUrl"]" method="post">
+    <ul asp-validation-summary="All" class="flashes"></ul>
+    <div class="form-group">
+        <label asp-for="UserName">Username</label>
+        <input asp-for="UserName" class="form-control"/>
+        <span asp-validation-for="UserName" class="text-danger"></span>
     </div>
-</div>
+    <div class="form-group">
+        <label asp-for="Password">Password</label>
+        <input asp-for="Password" class="form-control"/>
+        <span asp-validation-for="Password" class="text-danger"></span>
+    </div>
+    <div class="form-group">
+        <div class="checkbox">
+            <label asp-for="RememberMe">
+                <input asp-for="RememberMe"/>
+                @Html.DisplayNameFor(m => m.RememberMe)
+            </label>
+        </div>
+    </div>
+    <div class="form-group">
+        <input type="submit" value="Log in"/>
+    </div>
+</form>
 
 @section Scripts {
     @await Html.PartialAsync("_ValidationScriptsPartial")

--- a/MiniTwit.Web.App/Views/Account/LogIn.cshtml
+++ b/MiniTwit.Web.App/Views/Account/LogIn.cshtml
@@ -11,12 +11,12 @@
     <ul asp-validation-summary="All" class="flashes"></ul>
     <div class="form-group">
         <label asp-for="UserName">Username</label>
-        <input asp-for="UserName" class="form-control"/>
+        <input asp-for="UserName" class="form-control" required autofocus/>
         <span asp-validation-for="UserName" class="text-danger"></span>
     </div>
     <div class="form-group">
         <label asp-for="Password">Password</label>
-        <input asp-for="Password" class="form-control"/>
+        <input asp-for="Password" class="form-control" required/>
         <span asp-validation-for="Password" class="text-danger"></span>
     </div>
     <div class="form-group">

--- a/MiniTwit.Web.App/Views/Account/Register.cshtml
+++ b/MiniTwit.Web.App/Views/Account/Register.cshtml
@@ -5,36 +5,32 @@
 }
 
 <h2>@ViewData["Title"]</h2>
-<div class="row">
-    <div class="col-md-4">
-        <form asp-route-returnUrl="@ViewData["ReturnUrl"]" method="post">
-            <h4>Create a new account.</h4>
-            <hr/>
-            <div asp-validation-summary="All" class="text-danger"></div>
-            <div class="form-group">
-                <label asp-for="UserName"></label>
-                <input asp-for="UserName" class="form-control"/>
-                <span asp-validation-for="UserName" class="text-danger"></span>
-            </div>
-            <div class="form-group">
-                <label asp-for="Email"></label>
-                <input asp-for="Email" class="form-control"/>
-                <span asp-validation-for="Email" class="text-danger"></span>
-            </div>
-            <div class="form-group">
-                <label asp-for="Password"></label>
-                <input asp-for="Password" class="form-control"/>
-                <span asp-validation-for="Password" class="text-danger"></span>
-            </div>
-            <div class="form-group">
-                <label asp-for="PasswordRepeat"></label>
-                <input asp-for="PasswordRepeat" class="form-control"/>
-                <span asp-validation-for="PasswordRepeat" class="text-danger"></span>
-            </div>
-            <button type="submit" class="btn btn-default">Register</button>
-        </form>
+<form asp-route-returnUrl="@ViewData["ReturnUrl"]" method="post">
+    <ul asp-validation-summary="All" class="flashes"></ul>
+    <div class="form-group">
+        <label asp-for="UserName">Username</label>
+        <input asp-for="UserName" class="form-control" required autofocus/>
+        <span asp-validation-for="UserName" class="text-danger"></span>
     </div>
-</div>
+    <div class="form-group">
+        <label asp-for="Email">Email</label>
+        <input asp-for="Email" class="form-control" required/>
+        <span asp-validation-for="Email" class="text-danger"></span>
+    </div>
+    <div class="form-group">
+        <label asp-for="Password">Password</label>
+        <input asp-for="Password" class="form-control" required/>
+        <span asp-validation-for="Password" class="text-danger"></span>
+    </div>
+    <div class="form-group">
+        <label asp-for="PasswordRepeat">
+            Password <small>(repeat)</small>
+        </label>
+        <input asp-for="PasswordRepeat" class="form-control" required/>
+        <span asp-validation-for="PasswordRepeat" class="text-danger"></span>
+    </div>
+    <input type="submit" class="btn btn-default" value="Sign Up"/>
+</form>
 
 @section Scripts {
     @await Html.PartialAsync("_ValidationScriptsPartial")

--- a/MiniTwit.Web.App/Views/Shared/_Layout.cshtml
+++ b/MiniTwit.Web.App/Views/Shared/_Layout.cshtml
@@ -19,20 +19,30 @@
             //hacky, but its the easiest way to get them inline.
 
             <form method="post" asp-area="" asp-controller="Account" asp-action="LogOut">
-                <a asp-area="" asp-controller="Home" asp-action="My_Timeline" class="link">my timeline</a>
-                @("|")
-                <a asp-area="" asp-controller="Home" asp-action="Index" class="link">public timeline</a>
-                @("|")
+                <a asp-area="" asp-controller="Home" asp-action="My_Timeline" class="link">
+                    <span class="content">my timeline</span>
+                </a>
+                
+                <a asp-area="" asp-controller="Home" asp-action="Index" class="link">
+                    <span class="content">public timeline</span>
+                </a>
+                
                 <input id="LogoutButton" type="submit" value="sign out" class="link"/>
             </form>
         }
         else
         {
-            <a asp-area="" asp-controller="Home" asp-action="Index" class="link">public timeline</a>
-            @("|")
-            <a asp-area="" asp-controller="Account" asp-action="Register" class="link">sign up</a>
-            @("|")
-            <a asp-area="" asp-controller="Account" asp-action="LogIn" class="link">sign in</a>
+            <a asp-area="" asp-controller="Home" asp-action="Index" class="link">
+                <span class="content">public timeline</span>
+            </a>
+            
+            <a asp-area="" asp-controller="Account" asp-action="Register" class="link">
+                <span class="content">sign up</span>
+            </a>
+            
+            <a asp-area="" asp-controller="Account" asp-action="LogIn" class="link">
+                <span class="content">sign in</span>
+            </a>
         }
     </div>
     @*
@@ -55,6 +65,11 @@
     </div>
     <div class="footer">
         MiniTwit &mdash; A C# Application
+
+        <div class="links">
+            <a target="_blank" rel="noopener noreferrer" href="https://status.minitwit.tk">Status page</a>
+            <a target="_blank" rel="noopener noreferrer" href="https://github.com/jlndk/devoops">Source Code</a>
+        </div>
     </div>
 </div>
 

--- a/MiniTwit.Web.App/Views/Shared/_Layout.cshtml
+++ b/MiniTwit.Web.App/Views/Shared/_Layout.cshtml
@@ -5,7 +5,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>@ViewData["Title"] @("|") MiniTwit</title>
     <link rel="stylesheet" type="text/css" href="~/css/site.css"/>
 </head>
@@ -19,20 +19,20 @@
             //hacky, but its the easiest way to get them inline.
 
             <form method="post" asp-area="" asp-controller="Account" asp-action="LogOut">
-                <a asp-area="" asp-controller="Home" asp-action="My_Timeline">My Timeline</a>
+                <a asp-area="" asp-controller="Home" asp-action="My_Timeline" class="link">my timeline</a>
                 @("|")
-                <a asp-area="" asp-controller="Home" asp-action="Index">public timeline</a>
+                <a asp-area="" asp-controller="Home" asp-action="Index" class="link">public timeline</a>
                 @("|")
-                <input id="LogoutButton" type="submit" value="Logout"/>
+                <input id="LogoutButton" type="submit" value="sign out" class="link"/>
             </form>
         }
         else
         {
-            <a asp-area="" asp-controller="Home" asp-action="Index">public timeline</a>
+            <a asp-area="" asp-controller="Home" asp-action="Index" class="link">public timeline</a>
             @("|")
-            <a asp-area="" asp-controller="Account" asp-action="Register">sign up</a>
+            <a asp-area="" asp-controller="Account" asp-action="Register" class="link">sign up</a>
             @("|")
-            <a asp-area="" asp-controller="Account" asp-action="LogIn">sign in</a>
+            <a asp-area="" asp-controller="Account" asp-action="LogIn" class="link">sign in</a>
         }
     </div>
     @*

--- a/MiniTwit.Web.App/Views/Shared/_TwitBox.cshtml
+++ b/MiniTwit.Web.App/Views/Shared/_TwitBox.cshtml
@@ -9,7 +9,7 @@
         asp-area=""
         asp-controller="Home"
         asp-action="PostMessage">
-        <p/><input asp-for="Text" size="60"/><!--
+        <p/><input asp-for="Text"/><!--
         --><input type="submit" value="share"/>
     </form>
 </div>

--- a/MiniTwit.Web.App/wwwroot/css/site.css
+++ b/MiniTwit.Web.App/wwwroot/css/site.css
@@ -83,6 +83,21 @@ div.page div.navigation {
 div.page div.navigation .link {
     color: #444;
     font-weight: bold;
+    text-decoration: none;
+}
+
+div.page div.navigation .link .content {
+    text-decoration: underline;
+}
+
+div.page div.navigation .link:after
+{
+  content: ' |';
+}
+
+div.page div.navigation .link:last-child:after
+{
+  content: '';
 }
 
 div.page div.navigation input {
@@ -107,10 +122,12 @@ div.page div.body {
 }
 
 div.page div.footer {
+    display: flex;
     background: #eee;
     color: #888;
     padding: 5px 10px;
     font-size: 12px;
+    justify-content: space-between;
 }
 
 div.page div.followstatus {
@@ -227,5 +244,21 @@ div.error {
     input[type="password"],
     input[type="email"] { 
         width: 100%;
+    }
+
+    div.page div.footer {
+        flex-direction: column;
+        align-items: center;
+    }
+
+    div.page div.footer .links {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        font-size: 14px; 
+    }
+
+    .page .footer .links > * {
+        padding: 5px 0;
     }
 }

--- a/MiniTwit.Web.App/wwwroot/css/site.css
+++ b/MiniTwit.Web.App/wwwroot/css/site.css
@@ -83,10 +83,13 @@ div.page div.navigation {
 div.page div.navigation .link {
     color: #444;
     font-weight: bold;
+}
+
+div.page div.navigation a.link {
     text-decoration: none;
 }
 
-div.page div.navigation .link .content {
+div.page div.navigation a.link .content {
     text-decoration: underline;
 }
 
@@ -107,7 +110,6 @@ div.page div.navigation input {
     color: #444;
     text-decoration: underline;
     cursor: pointer;
-    font-size: 16px;
     letter-spacing: 0.5px;
 }
 

--- a/MiniTwit.Web.App/wwwroot/css/site.css
+++ b/MiniTwit.Web.App/wwwroot/css/site.css
@@ -1,168 +1,183 @@
-﻿body {
-    background: #CAECE9;
-    font-family: 'Trebuchet MS', sans-serif;
+﻿* {
+    box-sizing: border-box;
+}
+
+body {
+    background: #caece9;
+    font-family: "Trebuchet MS", sans-serif;
     font-size: 14px;
 }
 
 a {
-    color: #26776F;
+    color: #26776f;
 }
 
-    a:hover {
-        color: #333;
-    }
+a:hover {
+    color: #333;
+}
 
 input[type="text"],
-input[type="password"] {
+input[type="password"],
+input[type="email"] {
     background: white;
-    border: 1px solid #BFE6E2;
-    padding: 2px;
-    font-family: 'Trebuchet MS', sans-serif;
+    border: 1px solid #bfe6e2;
+    padding: 5px;
+    font-family: "Trebuchet MS", sans-serif;
     font-size: 14px;
-    -moz-border-radius: 2px;
-    -webkit-border-radius: 2px;
+    border-radius: 5px;
     color: #105751;
 }
 
 input[type="submit"] {
     background: #105751;
-    border: 1px solid #073B36;
-    padding: 1px 3px;
-    font-family: 'Trebuchet MS', sans-serif;
+    border: 1px solid #073b36;
+    padding: 5px 15px;
+    font-family: "Trebuchet MS", sans-serif;
     font-size: 14px;
     font-weight: bold;
-    -moz-border-radius: 2px;
-    -webkit-border-radius: 2px;
+    border-radius: 2px;
     color: white;
+}
+
+label {
+    display: block;
+}
+
+.form-group {
+    padding-bottom: 5px;
+}
+
+.text-danger {
+    display: block;
+    color: #dd2525;
 }
 
 div.page {
     background: white;
-    border: 1px solid #6ECCC4;
-    width: 700px;
+    border: 1px solid #6eccc4;
+    width: 100%;
+    max-width: 700px;
     margin: 30px auto;
 }
 
-    div.page h1 {
-        background: #6ECCC4;
-        margin: 0;
-        padding: 10px 14px;
-        color: white;
-        letter-spacing: 1px;
-        text-shadow: 0 0 3px #24776F;
-        font-weight: normal;
-    }
+div.page h1 {
+    background: #6eccc4;
+    margin: 0;
+    padding: 10px 14px;
+    color: white;
+    letter-spacing: 1px;
+    text-shadow: 0 0 3px #24776f;
+    font-weight: normal;
+}
 
-    div.page div.navigation {
-        background: #DEE9E8;
-        padding: 4px 10px;
-        border-top: 1px solid #ccc;
-        border-bottom: 1px solid #eee;
-        color: #888;
-        font-size: 12px;
-        letter-spacing: 0.5px;
-    }
+div.page div.navigation {
+    background: #dee9e8;
+    padding: 10px 10px;
+    border-top: 1px solid #ccc;
+    border-bottom: 1px solid #eee;
+    color: #888;
+    font-size: 14px;
+    letter-spacing: 0.5px;
+}
 
-        div.page div.navigation a {
-            color: #444;
-            font-weight: bold;
-        }
-        
-        div.page div.navigation input {
-            background: none;
-            border: none;
-            padding: 0;
-            color: #444;
-            text-decoration: underline;
-            cursor: pointer;
-            font-size: 12px;
-            letter-spacing: 0.5px;
-        }
+div.page div.navigation .link {
+    color: #444;
+    font-weight: bold;
+}
 
-        
+div.page div.navigation input {
+    background: none;
+    border: none;
+    padding: 0;
+    color: #444;
+    text-decoration: underline;
+    cursor: pointer;
+    font-size: 16px;
+    letter-spacing: 0.5px;
+}
+
 div.page h2 {
-        margin: 0 0 15px 0;
-        color: #105751;
-        text-shadow: 0 1px 2px #ccc;
-    }
+    margin: 0 0 15px 0;
+    color: #105751;
+    text-shadow: 0 1px 2px #ccc;
+}
 
-    div.page div.body {
-        padding: 10px;
-    }
+div.page div.body {
+    padding: 10px;
+}
 
-    div.page div.footer {
-        background: #eee;
-        color: #888;
-        padding: 5px 10px;
-        font-size: 12px;
-    }
+div.page div.footer {
+    background: #eee;
+    color: #888;
+    padding: 5px 10px;
+    font-size: 12px;
+}
 
-    div.page div.followstatus {
-        border: 1px solid #ccc;
-        background: #E3EBEA;
-        -moz-border-radius: 2px;
-        -webkit-border-radius: 2px;
-        padding: 3px;
-        font-size: 13px;
-    }
+div.page div.followstatus {
+    border: 1px solid #ccc;
+    background: #e3ebea;
+    border-radius: 2px;
+    padding: 3px;
+    font-size: 13px;
+}
 
-    div.page ul.messages {
-        list-style: none;
-        margin: 0;
-        padding: 0;
-    }
+div.page ul.messages {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
 
-        div.page ul.messages li {
-            margin: 10px 0;
-            padding: 5px;
-            background: #F0FAF9;
-            border: 1px solid #DBF3F1;
-            -moz-border-radius: 5px;
-            -webkit-border-radius: 5px;
-            min-height: 48px;
-        }
+div.page ul.messages li {
+    margin: 10px 0;
+    padding: 5px;
+    background: #f0faf9;
+    border: 1px solid #dbf3f1;
+    border-radius: 5px;
+    min-height: 48px;
+    box-sizing: content-box;
+}
 
-        div.page ul.messages p {
-            margin: 0;
-        }
+div.page ul.messages p {
+    margin: 0;
+}
 
-        div.page ul.messages li img {
-            float: left;
-            padding: 0 10px 0 0;
-        }
+div.page ul.messages li img {
+    float: left;
+    padding: 0 10px 0 0;
+}
 
-        div.page ul.messages li small {
-            font-size: 0.9em;
-            color: #888;
-        }
+div.page ul.messages li small {
+    font-size: 0.9em;
+    color: #888;
+}
 
-    div.page div.twitbox {
-        margin: 10px 0;
-        padding: 5px;
-        background: #F0FAF9;
-        border: 1px solid #94E2DA;
-        -moz-border-radius: 5px;
-        -webkit-border-radius: 5px;
-    }
+div.page div.twitbox {
+    margin: 10px 0;
+    padding: 5px;
+    background: #f0faf9;
+    border: 1px solid #94e2da;
+    border-radius: 5px;
+}
 
-        div.page div.twitbox h3 {
-            margin: 0;
-            font-size: 1em;
-            color: #2C7E76;
-        }
+div.page div.twitbox h3 {
+    margin: 0;
+    font-size: 1em;
+    color: #2c7e76;
+}
 
-        div.page div.twitbox p {
-            margin: 0;
-        }
+div.page div.twitbox p {
+    margin: 0;
+}
 
-        div.page div.twitbox input[type="text"] {
-            width: 585px;
-        }
+div.page div.twitbox input[type="text"] {
+    width: 100%;
+    max-width: 585px;
+}
 
-        div.page div.twitbox input[type="submit"] {
-            width: 70px;
-            margin-left: 5px;
-        }
+div.page div.twitbox input[type="submit"] {
+    width: 70px;
+    margin-left: 5px;
+}
 
 ul.flashes {
     list-style: none;
@@ -170,21 +185,47 @@ ul.flashes {
     padding: 0;
 }
 
-    ul.flashes li {
-        background: #B9F3ED;
-        border: 1px solid #81CEC6;
-        -moz-border-radius: 2px;
-        -webkit-border-radius: 2px;
-        padding: 4px;
-        font-size: 13px;
-    }
+ul.flashes li {
+    background: #b9f3ed;
+    border: 1px solid #81cec6;
+    border-radius: 2px;
+    padding: 4px;
+    font-size: 13px;
+}
 
 div.error {
     margin: 10px 0;
-    background: #FAE4E4;
-    border: 1px solid #DD6F6F;
-    -moz-border-radius: 2px;
-    -webkit-border-radius: 2px;
+    background: #fae4e4;
+    border: 1px solid #dd6f6f;
+    border-radius: 2px;
     padding: 4px;
     font-size: 13px;
+}
+
+@media(max-width: 768px) {
+    body {
+        font-size: 16px;
+    }
+
+    div.page div.navigation {
+        font-size: 16px;
+    }
+}
+
+@media(max-width: 425px) {
+    div.page h1,
+    div.page h2 {
+        text-align: center;
+    }
+    
+
+    div.page div.navigation {
+        text-align: center;
+    }
+
+    input[type="text"],
+    input[type="password"],
+    input[type="email"] { 
+        width: 100%;
+    }
 }


### PR DESCRIPTION
fixes #92.
Also made text/labels in ui more polished (and more like the original minitwit) and adds links to our status page and repository.

I tried to stay as true to the era of the design as possible, while still added a11y to mobile users. I therefore increased the padding of most inputs and padding of links and buttons. In the same spirit I also tried to stay compatible with old IE versions, but had to give up and use flexbox a few places. If we still truly care about supporting IE8 from 10+ years ago, we could look into using some CSS hacks.

# Screenshots
## Mobile (using a iphone 5 screen size)
![localhost_timeline](https://user-images.githubusercontent.com/3009101/75518557-7ef9f900-5a01-11ea-93cc-28c6cf5de1f2.png)
![localhost_register](https://user-images.githubusercontent.com/3009101/75518560-7f928f80-5a01-11ea-9afc-9c95903465d8.png)
![localhost_login](https://user-images.githubusercontent.com/3009101/75518562-802b2600-5a01-11ea-8001-b624a556794c.png)

## Desktop
![localhost_desktop_login](https://user-images.githubusercontent.com/3009101/75518571-85887080-5a01-11ea-98de-6de4bcf5919e.png)
![localhost_desktop_register](https://user-images.githubusercontent.com/3009101/75518574-86210700-5a01-11ea-8608-f1c2ee617d37.png)
![localhost_desktop_timeline](https://user-images.githubusercontent.com/3009101/75518575-86210700-5a01-11ea-8479-c28379dcf5cb.png)
