### PR TITLE
Added support for dynamic gravatar profile pictures

### DIFF
--- a/MiniTwit.Web.App/TagHelpers/GravatarTagHelper.cs
+++ b/MiniTwit.Web.App/TagHelpers/GravatarTagHelper.cs
@@ -1,0 +1,74 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+//Based on https://github.com/anuraj/AspNetCoreSamples/tree/master/TagHelperDemo
+namespace MiniTwit.Web.App.TagHelpers
+{
+    [HtmlTargetElement("img", Attributes = "gravatar-email")]
+    public class GravatarTagHelper : TagHelper
+    {
+        [HtmlAttributeName("gravatar-email")]
+        public string Email { get; set; }
+        [HtmlAttributeName("gravatar-mode")]
+        public Mode Mode { get; set; } = Mode.Mm;
+        [HtmlAttributeName("gravatar-rating")]
+        public Rating Rating { get; set; } = Rating.g;
+        [HtmlAttributeName("gravatar-size")]
+        public int Size { get; set; } = 50;
+        public override void Process(TagHelperContext context, TagHelperOutput output)
+        {
+            using (var md5 = MD5.Create())
+            {
+                var result = md5.ComputeHash(Encoding.ASCII.GetBytes(Email));
+                var hash = BitConverter.ToString(result).Replace("-", "").ToLower();
+                var url = $"http://gravatar.com/avatar/{hash}";
+                var queryBuilder = new QueryBuilder();
+                queryBuilder.Add("s", Size.ToString());
+                queryBuilder.Add("d", GetModeValue(Mode));
+                queryBuilder.Add("r", Rating.ToString());
+                url = url + Uri.EscapeUriString(queryBuilder.ToQueryString().ToString());
+                output.Attributes.SetAttribute("src", url);
+            }
+        }
+
+        private static string GetModeValue(Mode mode)
+        {
+            if (mode == Mode.NotFound)
+            {
+                return "404";
+            }
+
+            return mode.ToString().ToLower();
+        }
+    }
+
+    public enum Rating
+    {
+        g,
+        pg,
+        r,
+        x
+    }
+
+    public enum Mode
+    {
+        [Display(Name = "404")]
+        NotFound,
+        [Display(Name = "Mm")]
+        Mm,
+        [Display(Name = "Identicon")]
+        Identicon,
+        [Display(Name = "Monsterid")]
+        Monsterid,
+        [Display(Name = "Wavatar")]
+        Wavatar,
+        [Display(Name = "Retro")]
+        Retro,
+        [Display(Name = "Blank")]
+        Blank
+    }
+}

--- a/MiniTwit.Web.App/Views/Shared/_Messages.cshtml
+++ b/MiniTwit.Web.App/Views/Shared/_Messages.cshtml
@@ -9,9 +9,9 @@
             @foreach (var msg in messages)
             {
                 <li>
-                    <img src="https://www.gravatar.com/avatar/00000000000000000000000000000000?d=mp&s=48"/> <!--TODO remember to softcode-->
+                    <img gravatar-email="@msg.Author.Email" gravatar-size="48"/>
                     <strong>
-                        <a asp-area="" asp-controller="Home" asp-action="User_Timeline" asp-route-username=@msg.Author.UserName>@msg.Author.UserName</a>
+                        <a asp-area="" asp-controller="Home" asp-action="User_Timeline" asp-route-username="@msg.Author.UserName">@msg.Author.UserName</a>
                     </strong>
                         @msg.Text
                     <small>

--- a/MiniTwit.Web.App/Views/_ViewImports.cshtml
+++ b/MiniTwit.Web.App/Views/_ViewImports.cshtml
@@ -2,3 +2,4 @@
 @using MiniTwit.Web.App.Models
 @using MiniTwit.Entities
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@addTagHelper *, MiniTwit.Web.App


### PR DESCRIPTION
closes #84 

I used a really cool so-called "taghelper" (https://dotnetthoughts.net/aspnet-core-gravatar-taghelper/) as the foundation for now making the proper gravatar URL's based on the users email address, which means they will see their own profile picture, if they have added one to gravatar. All the other arguments are the same