### PR TITLE
Add monitoring with prometheus and grafana

### DIFF
--- a/MiniTwit.Web.App/MiniTwit.Web.App.csproj
+++ b/MiniTwit.Web.App/MiniTwit.Web.App.csproj
@@ -16,6 +16,8 @@
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="prometheus-net" Version="3.5.0" />
+    <PackageReference Include="prometheus-net.AspNetCore" Version="3.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MiniTwit.Web.App/Startup.cs
+++ b/MiniTwit.Web.App/Startup.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using MiniTwit.Entities;
 using MiniTwit.Models;
+using Prometheus;
 
 namespace MiniTwit.Web.App
 {
@@ -57,6 +58,10 @@ namespace MiniTwit.Web.App
                 app.UseExceptionHandler("/Home/Error");
                 app.UseHsts();
             }
+            
+            app.UseMetricServer();
+            app.UseHttpMetrics();
+
             app.UseStatusCodePages();
             app.UseStatusCodePagesWithReExecute("/StatusCode/Status{0}");
             app.UseStaticFiles();
@@ -69,6 +74,9 @@ namespace MiniTwit.Web.App
                     "default",
                     "{controller=Home}/{action=Index}/{id?}");
             });
+
+            
+
             using var serviceScope = app.ApplicationServices.GetService<IServiceScopeFactory>().CreateScope();
             var context = serviceScope.ServiceProvider.GetRequiredService<MiniTwitContext>();
             context.Database.Migrate();

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,4 +1,9 @@
 version: "3.4"
+
+volumes:
+    prometheus_data: {}
+    grafana_data: {}
+
 services:
     traefik:
         image: traefik:v2.1
@@ -74,6 +79,8 @@ services:
             - "traefik.http.routers.webapp-secure.tls.certresolver=webappresolver"
         depends_on:
             - database
+            - prometheus
+            - grafana
 
     database:
         image: postgres:12
@@ -82,3 +89,21 @@ services:
             - "POSTGRES_PASSWORD=test"
         volumes:
             - ./postgresdata:/var/lib/postgresql/data
+
+    prometheus:
+        image: prom/prometheus
+        container_name: prometheus
+        ports:
+            - "9090:9090"  
+        volumes:
+            - ./prometheus.yml:/etc/prometheus/prometheus.yml
+            - prometheus_data:/prometheus
+
+    grafana:
+        image: grafana/grafana
+        ports:
+            - "3000:3000"  
+        volumes:
+            - grafana_data:/var/lib/grafana
+        depends_on: 
+            - prometheus

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,9 @@
 version: "3.4"
+
+volumes:
+    prometheus_data: {}
+    grafana_data: {}
+
 services:
     traefik:
         image: traefik:v2.1
@@ -41,6 +46,8 @@ services:
             - "traefik.http.routers.webapp.entrypoints=http"
         depends_on:
             - database
+            - prometheus
+            - grafana
 
     database:
         image: postgres:12
@@ -50,3 +57,21 @@ services:
             - "5432:5432"
         volumes:
             - ./postgresdata:/var/lib/postgresql/data
+
+    prometheus:
+        image: prom/prometheus
+        container_name: prometheus
+        ports:
+            - "9090:9090"  
+        volumes:
+            - ./prometheus.yml:/etc/prometheus/prometheus.yml
+            - prometheus_data:/prometheus
+
+    grafana:
+        image: grafana/grafana
+        ports:
+            - "3000:3000"  
+        volumes:
+            - grafana_data:/var/lib/grafana
+        depends_on: 
+            - prometheus

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,29 @@
+global:
+  scrape_interval:     15s # By default, scrape targets every 15 seconds.
+  evaluation_interval: 15s # Evaluate rules every 15 seconds.
+
+  # Attach these extra labels to all timeseries collected by this Prometheus instance.
+  external_labels:
+    monitor: 'codelab-monitor'
+
+rule_files:
+  - 'prometheus.rules.yml'
+
+scrape_configs:
+  - job_name: 'prometheus'
+
+    # Override the global default and scrape targets from this job every 5 seconds.
+    scrape_interval: 5s
+
+    static_configs:
+      - targets: ['prometheus:9090']
+
+  - job_name:       'itu-minittwit-app'
+
+    # Override the global default and scrape targets from this job every 5 seconds.
+    scrape_interval: 5s
+
+    static_configs:
+      - targets: ['webapp:80']
+        labels:
+          group: 'production'


### PR DESCRIPTION
Just basic monitoring of built in stuff from prometheus net. All ports are currently exposes, and no admin user exists, so its just admin admin. We might want to fix that later, but it works for now.
Data from prometheus and grafana should persist between restarts.