### PR TITLE
Kestrel balancer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN dotnet publish -c release -o /app --no-restore
 
 FROM build AS development
 WORKDIR /app
-ENTRYPOINT ["dotnet", "watch", "--project", "MiniTwit.Web.App", "run"]
+ENTRYPOINT ["dotnet", "watch", "--project", "MiniTwit.Web.App", "run", "--urls", "http://0.0.0.0:80;http://0.0.0.0:443"]
 
 FROM mcr.microsoft.com/dotnet/core/aspnet:3.1 as production
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,9 +30,9 @@ RUN dotnet publish -c release -o /app --no-restore
 
 FROM build AS development
 WORKDIR /app
-ENTRYPOINT ["dotnet", "watch", "--project", "MiniTwit.Web.App", "run"]
+ENTRYPOINT ["dotnet", "watch", "--project", "MiniTwit.Web.App", "run", "--urls", "http://0.0.0.0:80;https://0.0.0.0:443"]
 
 FROM mcr.microsoft.com/dotnet/core/aspnet:3.1 as production
 WORKDIR /app
 COPY --from=build /app ./
-ENTRYPOINT ["dotnet", "MiniTwit.Web.App.dll"]
+ENTRYPOINT ["dotnet", "MiniTwit.Web.App.dll", "--urls", "http://0.0.0.0:80;https://0.0.0.0:443"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN dotnet publish -c release -o /app --no-restore
 
 FROM build AS development
 WORKDIR /app
-ENTRYPOINT ["dotnet", "watch", "--project", "MiniTwit.Web.App", "run", "--urls", "http://0.0.0.0:80;http://0.0.0.0:443"]
+ENTRYPOINT ["dotnet", "watch", "--project", "MiniTwit.Web.App", "run"]
 
 FROM mcr.microsoft.com/dotnet/core/aspnet:3.1 as production
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN dotnet publish -c release -o /app --no-restore
 
 FROM build AS development
 WORKDIR /app
-ENTRYPOINT ["dotnet", "watch", "--project", "MiniTwit.Web.App", "run", "--urls", "http://0.0.0.0:80"]
+ENTRYPOINT ["dotnet", "watch", "--project", "MiniTwit.Web.App", "run"]
 
 FROM mcr.microsoft.com/dotnet/core/aspnet:3.1 as production
 WORKDIR /app

--- a/MiniTwit.Web.App/MiniTwit.Web.App.csproj
+++ b/MiniTwit.Web.App/MiniTwit.Web.App.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="McMaster.AspNetCore.LetsEncrypt" Version="0.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.1" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="3.1.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.1" />

--- a/MiniTwit.Web.App/Startup.cs
+++ b/MiniTwit.Web.App/Startup.cs
@@ -24,6 +24,14 @@ namespace MiniTwit.Web.App
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddLetsEncrypt(o =>
+            {
+                o.DomainNames = new[] { "metamagicgames.com" };
+                o.UseStagingServer = true; // <--- use staging
+
+                o.AcceptTermsOfService = true;
+                o.EmailAddress = "jooln@itu.dk";
+            });
             services.AddControllersWithViews();
             services.AddDbContext<MiniTwitContext>();
             services.AddScoped<IMiniTwitContext>(provider => provider.GetService<MiniTwitContext>());

--- a/MiniTwit.Web.App/Startup.cs
+++ b/MiniTwit.Web.App/Startup.cs
@@ -27,7 +27,7 @@ namespace MiniTwit.Web.App
             services.AddLetsEncrypt(o =>
             {
                 o.DomainNames = new[] { "metamagicgames.com" };
-                o.UseStagingServer = true; // <--- use staging
+                //o.UseStagingServer = true; // <--- use staging
 
                 o.AcceptTermsOfService = true;
                 o.EmailAddress = "jooln@itu.dk";

--- a/MiniTwit.Web.App/Startup.cs
+++ b/MiniTwit.Web.App/Startup.cs
@@ -66,7 +66,7 @@ namespace MiniTwit.Web.App
                 app.UseExceptionHandler("/Home/Error");
                 app.UseHsts();
             }
-            
+            app.UseHttpsRedirection();
             app.UseMetricServer();
             app.UseHttpMetrics();
 
@@ -76,6 +76,7 @@ namespace MiniTwit.Web.App
             app.UseAuthentication();
             app.UseRouting();
             app.UseAuthorization();
+            
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapControllerRoute(

--- a/MiniTwit.Web.App/Startup.cs
+++ b/MiniTwit.Web.App/Startup.cs
@@ -26,11 +26,11 @@ namespace MiniTwit.Web.App
         {
             services.AddLetsEncrypt(o =>
             {
-                o.DomainNames = new[] { "metamagicgames.com" };
+                o.DomainNames = new[] { "minitwit.tk" , "www.minitwit.tk"};
                 //o.UseStagingServer = true; // <--- use staging
 
                 o.AcceptTermsOfService = true;
-                o.EmailAddress = "jooln@itu.dk";
+                o.EmailAddress = "joln@itu.dk";
             });
             services.AddControllersWithViews();
             services.AddDbContext<MiniTwitContext>();

--- a/MiniTwit.Web.App/appsettings.Development.json
+++ b/MiniTwit.Web.App/appsettings.Development.json
@@ -5,5 +5,6 @@
       "Microsoft": "Warning",
       "Microsoft.Hosting.Lifetime": "Information"
     }
-  }
+  },
+  "server.urls": "http://0.0.0.0:443;http://0.0.0.0:80"
 }

--- a/MiniTwit.Web.App/appsettings.Development.json
+++ b/MiniTwit.Web.App/appsettings.Development.json
@@ -1,10 +1,10 @@
 {
+  "https_port": 443,
   "Logging": {
     "LogLevel": {
       "Default": "Information",
       "Microsoft": "Warning",
       "Microsoft.Hosting.Lifetime": "Information"
     }
-  },
-  "server.urls": "http://0.0.0.0:443;http://0.0.0.0:80"
+  }
 }

--- a/MiniTwit.Web.App/appsettings.json
+++ b/MiniTwit.Web.App/appsettings.json
@@ -1,10 +1,4 @@
 {
-    "https_port": 443,
-    "LetsEncrypt": {
-        "AcceptTermsOfService": true,
-        "DomainNames": [ "metamagicgames.com"],
-        "EmailAddress": "joln@itu.dk"
-    },
     "Logging": {
         "LogLevel": {
             "Default": "Information",

--- a/MiniTwit.Web.App/appsettings.json
+++ b/MiniTwit.Web.App/appsettings.json
@@ -1,4 +1,10 @@
 {
+
+    "LetsEncrypt": {
+        "AcceptTermsOfService": true,
+        "DomainNames": [ "metamagicgames.com"],
+        "EmailAddress": "joln@itu.dk"
+    },
     "Logging": {
         "LogLevel": {
             "Default": "Information",

--- a/MiniTwit.Web.App/appsettings.json
+++ b/MiniTwit.Web.App/appsettings.json
@@ -1,5 +1,5 @@
 {
-
+    "https_port": 443,
     "LetsEncrypt": {
         "AcceptTermsOfService": true,
         "DomainNames": [ "metamagicgames.com"],

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -5,45 +5,7 @@ volumes:
     grafana_data: {}
 
 services:
-    traefik:
-        image: traefik:v2.1
-        # Enables the web UI and tells Traefik to listen to docker
-        # @TODO: Secure traefik api/dashboard
-        command:
-            #- "--log.level=DEBUG"
-            - "--api.insecure=true"
-            - "--providers.docker=true"
-            - "--providers.docker.exposedbydefault=false"
-            - "--entrypoints.http.address=:80"
-
-            # HTTPS Config
-            - "--entrypoints.https.address=:443"
-            - "--certificatesresolvers.webappresolver.acme.tlschallenge=true"
-            - "--certificatesresolvers.webappresolver.acme.email=joln@itu.dk"
-            - "--certificatesresolvers.webappresolver.acme.storage=/letsencrypt/acme.json"
-            # Use Let's encrypt staging server
-            # - "--certificatesresolvers.webappresolver.acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory"
-        ports:
-            # The HTTP port
-            - "80:80"
-
-            # The HTTPS port
-            - "443:443"
-        volumes:
-            # So that Traefik can listen to the Docker events
-            - /var/run/docker.sock:/var/run/docker.sock:ro
-
-            # So that Traefik can persist the HTTP certificate
-            - ./letsencrypt:/letsencrypt
-        labels:
-            - "traefik.enable=true"
-            - "traefik.http.routers.api.rule=Host(`traefik.localhost`)||Host(`traefik.minitwit.tk`)"
-            - "traefik.http.routers.api.entrypoints=http"
-            - "traefik.http.routers.api.service=api@internal"
-            - "traefik.http.routers.api.middlewares=auth"
-            # Generate new user and password with `echo $(htpasswd -nb admin admin) | sed -e s/\\$/\\$\\$/g`
-            - "traefik.http.middlewares.auth.basicauth.users=admin:$$apr1$$vVJRD/Hd$$pzWF/71kOPnIfPqS6/t0D."
-
+    
     webapp:
         build:
             context: "."
@@ -59,24 +21,6 @@ services:
             - "POSTGRES_CONNECTIONSTRING=Host=database;Database=MiniTwit;Username=postgres;Password=test"
         volumes:
             - ./aspnetkeys:/root/.aspnet/DataProtection-Keys
-        labels:
-            # Tell traefik that this container should be exposed to the public
-            - "traefik.enable=true"
-            # Tell traefik which port our container listens on
-            - "traefik.http.services.webapp.loadbalancer.server.port=80"
-
-            # Add http entrypoint (Tell where the service should be available)
-            - "traefik.http.routers.webapp.rule=Host(`minitwit.tk`) || Path(`/{path:.*}`)"
-            - "traefik.http.routers.webapp.entrypoints=http"
-            # Redirect http to https
-            - "traefik.http.routers.webapp.middlewares=redirect-https@docker"
-            - "traefik.http.middlewares.redirect-https.redirectscheme.scheme=https"
-            - "traefik.http.middlewares.redirect-https.redirectscheme.permanent=true"
-
-            # Add https entrypoint
-            - "traefik.http.routers.webapp-secure.rule=Host(`minitwit.tk`) || Path(`/{path:.*}`)"
-            - "traefik.http.routers.webapp-secure.entrypoints=https"
-            - "traefik.http.routers.webapp-secure.tls.certresolver=webappresolver"
         depends_on:
             - database
             - prometheus

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
             - "ASPNETCORE_ENVIRONMENT=Development"
             - "MINITWIT_ENVIRONMENT=docker"
             - "POSTGRES_CONNECTIONSTRING=Host=database;Database=MiniTwit;Username=postgres;Password=test"
-            - "ASPNETCORE_URLS=https://0.0.0.0:443"
+            - "ASPNETCORE_URLS=https://0.0.0.0:443;https://0.0.0.0:80"
         volumes:
             - ./:/app
             - ./aspnetkeys:/root/.aspnet/DataProtection-Keys

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,6 @@ services:
             - "ASPNETCORE_ENVIRONMENT=Development"
             - "MINITWIT_ENVIRONMENT=docker"
             - "POSTGRES_CONNECTIONSTRING=Host=database;Database=MiniTwit;Username=postgres;Password=test"
-            - "ASPNETCORE_URLS=https://0.0.0.0:443;https://0.0.0.0:80"
         volumes:
             - ./:/app
             - ./aspnetkeys:/root/.aspnet/DataProtection-Keys

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,25 +5,6 @@ volumes:
     grafana_data: {}
 
 services:
-    traefik:
-        image: traefik:v2.1
-        # Enables the web UI and tells Traefik to listen to docker
-        # @TODO: Secure traefik api/dashboard
-        command:
-            # General Config
-            #- "--log.level=DEBUG"
-            - "--api=true"
-            - "--api.dashboard=true"
-            - "--providers.docker=true"
-            - "--providers.docker.exposedbydefault=false"
-            - "--entrypoints.http.address=:80"
-        ports:
-            # The HTTP port
-            - "80:80"
-        volumes:
-            # So that Traefik can listen to the Docker events
-            - /var/run/docker.sock:/var/run/docker.sock:ro
-
     webapp:
         build:
             context: "."
@@ -33,21 +14,17 @@ services:
             - "ASPNETCORE_ENVIRONMENT=Development"
             - "MINITWIT_ENVIRONMENT=docker"
             - "POSTGRES_CONNECTIONSTRING=Host=database;Database=MiniTwit;Username=postgres;Password=test"
+            - "ASPNETCORE_URLS=https://0.0.0.0:443"
         volumes:
             - ./:/app
             - ./aspnetkeys:/root/.aspnet/DataProtection-Keys
-        labels:
-            # Tell traefik that this container should be exposed to the public
-            - "traefik.enable=true"
-            # Tell traefik which port our container listens on
-            - "traefik.http.services.webapp.loadbalancer.server.port=80"
-            # Tell where the service should be available
-            - "traefik.http.routers.webapp.rule=Path(`/{path:.*}`)"
-            - "traefik.http.routers.webapp.entrypoints=http"
         depends_on:
             - database
             - prometheus
             - grafana
+        ports:
+            - "80:80"
+            - "443:443"
 
     database:
         image: postgres:12


### PR DESCRIPTION
Removes Traefik and uses Kestrel instead. Should be quicker and get those rookie numbers up.
fixes #118 