### PR TITLE
Autorelease is better

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,16 @@
-name: create tagged release
+name: Create tagged release
 on:
   push:
     branches:
       - master
 
 jobs:
-  tagged-release:
-    name: Create Release
+  release-on-push:
     runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - name: Create Release
-        uses: "marvinpinto/action-automatic-releases@latest"
+      - uses: rymndhng/release-on-push-action@master
+        name: Create Release
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          prerelease: false
-          automatic_release_tag: "latest"
+          bump_version_scheme: minor


### PR DESCRIPTION
Resolves #129 Releases are no longer deleted upon creation of new releases. This uses the action found [here](https://github.com/marketplace/actions/tag-release-on-push-action). All releases are considered minor (will update the middle number) unless the PR is labeled `release:major` or `release:patch`. 

Tested on a private repo that can be found [here](https://github.com/Jakobis/DevOps-Tests/releases)