### PR TITLE
Fixed JSON naming on "latest" endpoint

### DIFF
--- a/MiniTwit.Web.App/Models/Api/GetLatestDTO.cs
+++ b/MiniTwit.Web.App/Models/Api/GetLatestDTO.cs
@@ -1,4 +1,3 @@
-using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 
 namespace MiniTwit.Web.App.Models.Api

--- a/MiniTwit.Web.App/Models/Api/GetLatestDTO.cs
+++ b/MiniTwit.Web.App/Models/Api/GetLatestDTO.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using Newtonsoft.Json;
 
 namespace MiniTwit.Web.App.Models.Api
 {
@@ -8,8 +9,8 @@ namespace MiniTwit.Web.App.Models.Api
         {
             Latest = latest;
         }
-        
-        [JsonPropertyName("latest")]
+
+        [JsonProperty(PropertyName = "latest")]
         public int Latest { get; set; }
     }
 }


### PR DESCRIPTION
close #148 

This PR fixes the json output of the `/api/latest` endpoint to have proper capitalization.