### PR TITLE
Small tweaks to gain top score in lighthouse

### DIFF
--- a/MiniTwit.Web.App/Views/Shared/_Layout.cshtml
+++ b/MiniTwit.Web.App/Views/Shared/_Layout.cshtml
@@ -8,6 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>@ViewData["Title"] @("|") MiniTwit</title>
     <link rel="stylesheet" type="text/css" href="~/css/site.css"/>
+    <meta name="Description" content="MiniTwit. Because writing todo lists is not fun"/>
 </head>
 <body>
 <div class="page">

--- a/MiniTwit.Web.App/Views/Shared/_Messages.cshtml
+++ b/MiniTwit.Web.App/Views/Shared/_Messages.cshtml
@@ -9,7 +9,7 @@
             @foreach (var msg in messages)
             {
                 <li>
-                    <img gravatar-email="@msg.Author.Email" gravatar-size="48"/>
+                    <img alt="Profile picture for @msg.Author.UserName" gravatar-email="@msg.Author.Email" gravatar-size="48"/>
                     <strong>
                         <a asp-area="" asp-controller="Home" asp-action="User_Timeline" asp-route-username="@msg.Author.UserName">@msg.Author.UserName</a>
                     </strong>

--- a/MiniTwit.Web.App/wwwroot/css/site.css
+++ b/MiniTwit.Web.App/wwwroot/css/site.css
@@ -3,7 +3,7 @@
 }
 
 body {
-    background: #caece9;
+    background: #b0e8e3;
     font-family: "Trebuchet MS", sans-serif;
     font-size: 14px;
 }
@@ -61,7 +61,7 @@ div.page {
 }
 
 div.page h1 {
-    background: #6eccc4;
+    background: #43a39b;
     margin: 0;
     padding: 10px 14px;
     color: white;
@@ -124,7 +124,7 @@ div.page div.body {
 div.page div.footer {
     display: flex;
     background: #eee;
-    color: #888;
+    color: #666;
     padding: 5px 10px;
     font-size: 12px;
     justify-content: space-between;
@@ -168,7 +168,7 @@ div.page ul.messages li img {
 
 div.page ul.messages li small {
     font-size: 0.9em;
-    color: #888;
+    color: #666;
 }
 
 div.page div.twitbox {


### PR DESCRIPTION
This PR introduces suble changes to the frontend, which fixes minor accessibility issues, reported by the build-in reporting tool in chrome, lighthouse.

Before this PR, our score looked like this:
![image](https://user-images.githubusercontent.com/3009101/79111594-19798600-7d7d-11ea-916c-4b03b5ff41ab.png)

After:
![image](https://user-images.githubusercontent.com/3009101/79111622-2ac29280-7d7d-11ea-8cb2-6204e505266d.png)
(Note: The reason "Best pracices" has regressed to 93 in the screenshot is because it has been performed locally where HTTP/2 is not possible, since HTTPS is disabled in development. This will however not be relavant in production, since HTTP/2 is active there).